### PR TITLE
Manage CSSRules with "Stylesheet" instance

### DIFF
--- a/src/StyleSheet/index.js
+++ b/src/StyleSheet/index.js
@@ -1,0 +1,62 @@
+const makeStyleSheet = () => {
+  const state = {
+    id: 0,
+    CSSRules: {}
+  }
+
+  const addRule = (id, styles) => {
+    state.CSSRules[id] = styles
+  }
+
+  const getRule = (id) => {
+    return state.CSSRules[id]
+  }
+
+  const hasRule = (id) => {
+    return !!getRule(id)
+  }
+
+  const removeRule = (id) => {
+    state.CSSRules[id] = undefined
+  }
+
+  const makeRule = (CSSRules) => {
+    state.id = state.id + 1
+    return { id: state.id, CSSRules }
+  }
+
+  const makeStyles = (props) => {
+    return generateStyles(props)
+  }
+
+  return {
+    addRule,
+    getRule,
+    hasRule,
+    removeRule,
+    makeRule,
+    makeStyles,
+    CSSRules: state.CSSRules
+  }
+}
+
+/**
+ * Creates the tokenized styles based.
+ */
+export const generateStyles = ({id, props, CSSRules}) => {
+  const parsedCSSRules = typeof CSSRules === 'function'
+    ? CSSRules(props) : CSSRules
+
+  return tokenize(id, parsedCSSRules)
+}
+
+/**
+ * Renders the CSSRule with tokenized with the unique ID.
+ *
+ * @param   {string} id
+ * @param   {string} CSSRules
+ * @returns {string}
+ */
+export const tokenize = (id, CSSRules) => `/* ${id} */\n${CSSRules.trim()}\n`
+
+export default makeStyleSheet

--- a/src/utilities/id.js
+++ b/src/utilities/id.js
@@ -1,5 +1,0 @@
-/**
- * Source
- * https://gist.github.com/jed/982883
- */
-export function uuid (a) { return a ? (0 | Math.random() * 16).toString(16) : ('' + 1e7 + -1e3 + -4e3 + -8e3 + -1e11).replace(/1|0/g, uuid) }

--- a/src/withStyles/__tests__/withStyles.test.js
+++ b/src/withStyles/__tests__/withStyles.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import withStyles, { removeStyle } from '../index'
+import withStyles from '../index'
+
+const removeStyle = withStyles.StyleSheet.removeRule
 
 describe('HOC Composition', () => {
   const Button = props => (<button {...props} />)

--- a/src/withStyles/helpers.js
+++ b/src/withStyles/helpers.js
@@ -1,5 +1,4 @@
-import { ID } from './index'
-import { uuid } from '../utilities/id'
+export const ID = '__REACT_REACTOR_STYLES__'
 
 /**
  * Creates the <style> tag, and adds it to the <head>.
@@ -27,20 +26,3 @@ export const getStyleTag = () => {
   const tag = document.getElementById(ID)
   return tag || makeStyleTag()
 }
-
-/**
- * Renders the CSSRule with tokenized with the unique ID.
- *
- * @param   {string} id
- * @param   {string} CSSRules
- * @returns {string}
- */
-export const tokenize = (id, CSSRules) => `/* ${id} */\n${CSSRules.trim()}\n`
-
-/**
- * Generates the styleProps with uniqueID for withStyles to consume.
- *
- * @param   {string} CSSRules
- * @returns {object}
- */
-export const makeCSS = (CSSRules) => ({ id: uuid(), CSSRules })


### PR DESCRIPTION
## Manage CSSRules with "Stylesheet" instance

This update refactors the previous implementation to use an instance to
track/manage/interface with `withStyle`, instead of relying purely on a
privately defined CONSTANT.

The UUID mechanism has also been replaced by a simple incrementing ID
mechanism. This nullifies the risk of collision and is simpler :).

Resolves:

https://github.com/awesomecss/reactor/issues/2
https://github.com/awesomecss/reactor/issues/1